### PR TITLE
Implement PasswordInput separately from TextInput

### DIFF
--- a/web/components/app/App.sass
+++ b/web/components/app/App.sass
@@ -12,3 +12,6 @@
 
 .App-intro
   font-size: large
+
+h5
+  font-size: 18px

--- a/web/components/demo/Demo.sass
+++ b/web/components/demo/Demo.sass
@@ -1,0 +1,3 @@
+div#demo
+  width: 50%
+  margin-left: 25%

--- a/web/components/demo/index.js
+++ b/web/components/demo/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { SecondaryButton, PrimaryButton, ProgressGroup } from '../input/buttons';
-import { TextInput } from '../input/text';
+import { TextInput, PasswordInput } from '../input/text';
 
 const ButtonCallback = e => console.log(`${e.currentTarget.textContent} button clicked!`);
 
@@ -32,7 +32,7 @@ class FrontEndComponents extends React.Component {
 
     const { active } = this.state;
     return (
-      <div>
+      <div id="demo">
         <p>Buttons</p>
         <br />
         <div>
@@ -72,11 +72,9 @@ class FrontEndComponents extends React.Component {
           error={error}
           id="errored"
           />
-        <TextInput
+        <PasswordInput
           placeholder="Hint text"
-          onBlur={this.onBlur}
           onChange={this.onPasswordChange}
-          password
           label="Password"
           value={password}
           id="password"

--- a/web/components/index.sass
+++ b/web/components/index.sass
@@ -1,5 +1,6 @@
 // Import all component styles here
 @import ./app/App
+@import ./demo/Demo
 @import ./navbar/Navbar
 @import ./input/buttons/index
 @import ./input/text/index

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.js
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.js
@@ -21,7 +21,7 @@ const PasswordInput = ({
   return (
     <div className="text-input password-input">
       <div>
-        <span>{label}</span>
+        <h5>{label}</h5>
         <Link to="/">Forgot?</Link>
       </div>
       <label

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.js
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
+const PasswordInput = ({
+  label,
+  onChange,
+  error,
+  placeholder,
+  value,
+  showErrorMessage,
+  id,
+}) => {
+  const inputProps = {
+    id,
+    placeholder,
+    onChange,
+    value,
+  };
+
+  return (
+    <div className="text-input password-input">
+      <label
+        htmlFor={id}
+        >
+        <div>
+          <span>{label}</span>
+          <Link to="/">Forgot?</Link>
+        </div>
+        <input
+          {...inputProps}
+          type="password"
+          className={error ? 'error' : ''}
+          />
+        { (error && showErrorMessage) ? (<p>{error.message}</p>) : (<div />) }
+      </label>
+    </div>
+  );
+};
+
+PasswordInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  error: PropTypes.object,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  showErrorMessage: PropTypes.bool,
+};
+
+export default PasswordInput;

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.js
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.js
@@ -20,13 +20,13 @@ const PasswordInput = ({
 
   return (
     <div className="text-input password-input">
+      <div>
+        <span>{label}</span>
+        <Link to="/">Forgot?</Link>
+      </div>
       <label
         htmlFor={id}
         >
-        <div>
-          <span>{label}</span>
-          <Link to="/">Forgot?</Link>
-        </div>
         <input
           {...inputProps}
           type="password"

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.sass
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.sass
@@ -1,0 +1,15 @@
+div.password-input > label > div
+  display: flex
+  justify-content: space-between
+  align-items: center
+  width: 100%
+  max-width: 300px
+
+  > a
+    font-size: 14px
+
+    &:visited
+      color: $primary
+
+    &:hover
+      color: $secondary-highlight

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.sass
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.sass
@@ -1,4 +1,4 @@
-div.password-input > label > div
+div.password-input > div
   display: flex
   justify-content: space-between
   align-items: center

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.test.js
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.test.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+import { PasswordInput } from '.';
+
+beforeAll(() => {
+  configure({ adapter: new Adapter() });
+});
+
+describe('PasswordInput component', () => {
+  let wrapper;
+  const getWrapper = props => shallow(<PasswordInput {...props} />);
+
+  const value = 'some text';
+
+  describe('text', () => {
+    const props = {
+      value,
+      placeholder: 'some placeholder',
+      label: 'some label',
+      id: 'some input',
+    };
+
+    beforeEach(() => {
+      wrapper = getWrapper(props);
+    });
+
+    it('input value matches props value', () => {
+      expect(wrapper.find('input').props()).toHaveProperty('value', 'some text');
+    });
+
+    it('input placeholder matches props placeholder', () => {
+      expect(wrapper.find('input').props()).toHaveProperty('placeholder', 'some placeholder');
+    });
+
+    it('input label matches props label', () => {
+      expect(wrapper.find('span').text()).toBe('some label');
+    });
+  });
+
+  describe('password', () => {
+    const props = {
+      value,
+      label: 'some label',
+      id: 'some input',
+    };
+
+    beforeEach(() => {
+      wrapper = getWrapper(props);
+    });
+
+    it('input has password type', () => {
+      expect(wrapper.find('input').props()).toHaveProperty('type', 'password');
+    });
+  });
+
+  describe('error', () => {
+    const props = {
+      value,
+      label: 'some label',
+      id: 'some input',
+    };
+
+    describe('when there is an error', () => {
+      beforeEach(() => {
+        props.error = { message: 'something went horribly wrong' };
+        wrapper = getWrapper(props);
+      });
+
+      it('input class is error', () => {
+        expect(wrapper.find('input').hasClass('error')).toBeTruthy();
+      });
+
+      it('input contains error message', () => {
+        expect(wrapper.find('p').length).toBe(0);
+      });
+
+      describe('when showErrorMessage is true', () => {
+        beforeEach(() => {
+          props.showErrorMessage = true;
+          wrapper = getWrapper(props);
+        });
+
+        it('input contains error message', () => {
+          expect(wrapper.find('p').text()).toBe('something went horribly wrong');
+        });
+      });
+    });
+
+    describe('when there is no error', () => {
+      beforeEach(() => {
+        props.error = null;
+        wrapper = getWrapper(props);
+      });
+
+      it('input class does not have error', () => {
+        expect(wrapper.find('input').hasClass('error')).toBeFalsy();
+      });
+
+      it('input does not contain error message', () => {
+        expect(wrapper.find('p')).toHaveProperty('length', 0);
+      });
+    });
+  });
+
+  describe('onChange', () => {
+    let newValue = '';
+    const event = { target: { value: 'another text' } };
+    const onChange = (e) => { newValue = e.target.value; };
+    const props = {
+      label: 'some label',
+      id: 'some input',
+      onChange,
+    };
+
+    beforeEach(() => {
+      wrapper = getWrapper(props);
+    });
+
+    it('onChange is called when value is changed', () => {
+      wrapper.find('input').simulate('change', event);
+      expect(newValue).toEqual('another text');
+    });
+  });
+});

--- a/web/components/input/text/TextInput/PasswordInput/PasswordInput.test.js
+++ b/web/components/input/text/TextInput/PasswordInput/PasswordInput.test.js
@@ -35,7 +35,7 @@ describe('PasswordInput component', () => {
     });
 
     it('input label matches props label', () => {
-      expect(wrapper.find('span').text()).toBe('some label');
+      expect(wrapper.find('h5').text()).toBe('some label');
     });
   });
 

--- a/web/components/input/text/TextInput/PasswordInput/index.js
+++ b/web/components/input/text/TextInput/PasswordInput/index.js
@@ -1,0 +1,5 @@
+import PasswordInput from './PasswordInput';
+
+export {
+  PasswordInput,
+};

--- a/web/components/input/text/TextInput/TextInput.js
+++ b/web/components/input/text/TextInput/TextInput.js
@@ -23,11 +23,10 @@ const TextInput = ({
 
   return (
     <div className="text-input">
+      <div>{label}</div>
       <label
         htmlFor={id}
         >
-        {label}
-        <br />
         <input
           {...inputProps}
           className={error ? 'error' : ''}

--- a/web/components/input/text/TextInput/TextInput.js
+++ b/web/components/input/text/TextInput/TextInput.js
@@ -23,7 +23,7 @@ const TextInput = ({
 
   return (
     <div className="text-input">
-      <div>{label}</div>
+      <h5>{label}</h5>
       <label
         htmlFor={id}
         >

--- a/web/components/input/text/TextInput/TextInput.js
+++ b/web/components/input/text/TextInput/TextInput.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TextInput = ({
+  label,
+  onChange,
+  onBlur,
+  error,
+  placeholder,
+  value,
+  disabled,
+  showErrorMessage,
+  id,
+}) => {
+  const inputProps = {
+    id,
+    placeholder,
+    onChange,
+    onBlur,
+    value,
+    disabled,
+  };
+
+  return (
+    <div className="text-input">
+      <label
+        htmlFor={id}
+        >
+        {label}
+        <br />
+        <input
+          {...inputProps}
+          className={error ? 'error' : ''}
+          />
+        { (error && showErrorMessage) ? (<p>{error.message}</p>) : (<div />) }
+      </label>
+    </div>
+  );
+};
+
+TextInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onBlur: PropTypes.func,
+  error: PropTypes.object,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  showErrorMessage: PropTypes.bool,
+};
+
+export default TextInput;

--- a/web/components/input/text/TextInput/TextInput.sass
+++ b/web/components/input/text/TextInput/TextInput.sass
@@ -6,50 +6,50 @@ div.text-input
     font-weight: normal
     font-size: 18px
 
-  > label
+  > div
     /* Body text */
     color: $primary
 
-    > input
-      background: $white
-      max-width: 300px
-      width: 100%
-      height: 40px
-      border: 1px solid $grey-slate
-      box-sizing: border-box
-      border-radius: 4px
+  > label > input
+    background: $white
+    max-width: 300px
+    width: 100%
+    height: 40px
+    border: 1px solid $grey-slate
+    box-sizing: border-box
+    border-radius: 4px
 
-      padding-left: 16px
-      padding-right: 16px
-      padding-top: 8px
-      padding-bottom: 8px
+    padding-left: 16px
+    padding-right: 16px
+    padding-top: 8px
+    padding-bottom: 8px
 
-      margin-top: 8px
+    margin-top: 8px
 
-      color: $grey-dark
+    color: $grey-dark
+
+    &.error
+      border-color: $error
+
+    &::placeholder
+      color: $grey-slate
+
+    &:hover
+      border-color: $primary
 
       &.error
-        border-color: $error
+        border-color: $error-dark
 
-      &::placeholder
-        color: $grey-slate
+      &:disabled
+        cursor: not-allowed
+        border-color: $grey-slate
 
-      &:hover
-        border-color: $primary
+    &:focus
+      outline: none
+      border-color: $primary
 
-        &.error
-          border-color: $error-dark
-
-        &:disabled
-          cursor: not-allowed
-          border-color: $grey-slate
-
-      &:focus
-        outline: none
-        border-color: $primary
-
-        &.error
-          border-color: $error-dark
+      &.error
+        border-color: $error-dark
 
   p
     margin-top: 4px

--- a/web/components/input/text/TextInput/TextInput.sass
+++ b/web/components/input/text/TextInput/TextInput.sass
@@ -12,7 +12,8 @@ div.text-input
 
     > input
       background: $white
-      width: 274px
+      max-width: 300px
+      width: 100%
       height: 40px
       border: 1px solid $grey-slate
       box-sizing: border-box

--- a/web/components/input/text/TextInput/TextInput.sass
+++ b/web/components/input/text/TextInput/TextInput.sass
@@ -6,8 +6,7 @@ div.text-input
     font-weight: normal
     font-size: 18px
 
-  > div
-    /* Body text */
+  h5
     color: $primary
 
   > label > input

--- a/web/components/input/text/TextInput/TextInput.test.js
+++ b/web/components/input/text/TextInput/TextInput.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import TextInput from '.';
+import { TextInput } from '.';
 
 beforeAll(() => {
   configure({ adapter: new Adapter() });
@@ -39,46 +39,6 @@ describe('TextInput component', () => {
     });
   });
 
-  describe('password', () => {
-    const props = {
-      value,
-      label: 'some label',
-      id: 'some input',
-    };
-
-    describe('when password is true', () => {
-      beforeEach(() => {
-        props.password = true;
-        wrapper = getWrapper(props);
-      });
-
-      it('input has password type', () => {
-        expect(wrapper.find('input').props()).toHaveProperty('type', 'password');
-      });
-    });
-
-    describe('when password is false', () => {
-      beforeEach(() => {
-        props.password = false;
-        wrapper = getWrapper(props);
-      });
-
-      it('input does not have password type', () => {
-        expect(wrapper.find('input').props()).not.toHaveProperty('type', 'password');
-      });
-    });
-
-    describe('when password is not specified', () => {
-      beforeEach(() => {
-        wrapper = getWrapper(props);
-      });
-
-      it('input does not have password type', () => {
-        expect(wrapper.find('input').props()).not.toHaveProperty('type', 'password');
-      });
-    });
-  });
-
   describe('error', () => {
     const props = {
       value,
@@ -92,12 +52,34 @@ describe('TextInput component', () => {
         wrapper = getWrapper(props);
       });
 
-      it('input class is error', () => {
-        expect(wrapper.find('input').hasClass('error')).toBeTruthy();
+      describe('when showErrorMessage is true', () => {
+        beforeEach(() => {
+          props.showErrorMessage = true;
+          wrapper = getWrapper(props);
+        });
+
+        it('input class is error', () => {
+          expect(wrapper.find('input').hasClass('error')).toBeTruthy();
+        });
+
+        it('input contains error message', () => {
+          expect(wrapper.find('p').text()).toBe('something went horribly wrong');
+        });
       });
 
-      it('input contains error message', () => {
-        expect(wrapper.find('p').text()).toBe('something went horribly wrong');
+      describe('when showErrorMessage is false', () => {
+        beforeEach(() => {
+          props.showErrorMessage = false;
+          wrapper = getWrapper(props);
+        });
+
+        it('input class is error', () => {
+          expect(wrapper.find('input').hasClass('error')).toBeTruthy();
+        });
+
+        it('input contains error message', () => {
+          expect(wrapper.find('p')).toHaveProperty('length', 0);
+        });
       });
     });
 

--- a/web/components/input/text/TextInput/TextInput.test.js
+++ b/web/components/input/text/TextInput/TextInput.test.js
@@ -35,7 +35,7 @@ describe('TextInput component', () => {
     });
 
     it('input label matches props label', () => {
-      expect(wrapper.find('label').text()).toBe('some label');
+      expect(wrapper.find('h5').text()).toBe('some label');
     });
   });
 

--- a/web/components/input/text/TextInput/index.js
+++ b/web/components/input/text/TextInput/index.js
@@ -1,55 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import TextInput from './TextInput';
+import { PasswordInput } from './PasswordInput';
 
-const TextInput = ({
-  label,
-  onChange,
-  onBlur,
-  password,
-  error,
-  placeholder,
-  value,
-  disabled,
-  id,
-}) => {
-  const inputProps = {
-    id,
-    placeholder,
-    onChange,
-    onBlur,
-    value,
-    disabled,
-  };
-
-  if (password) inputProps.type = 'password';
-
-  return (
-    <div className="text-input">
-      <label
-        htmlFor={id}
-        >
-        {label}
-        <br />
-        <input
-          {...inputProps}
-          className={error ? 'error' : ''}
-          />
-        { error ? (<p>{error.message}</p>) : (<div />) }
-      </label>
-    </div>
-  );
+export {
+  TextInput,
+  PasswordInput,
 };
-
-TextInput.propTypes = {
-  label: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
-  onBlur: PropTypes.func,
-  password: PropTypes.bool,
-  error: PropTypes.object,
-  placeholder: PropTypes.string,
-  value: PropTypes.string,
-  disabled: PropTypes.bool,
-  id: PropTypes.string.isRequired,
-};
-
-export default TextInput;

--- a/web/components/input/text/index.js
+++ b/web/components/input/text/index.js
@@ -1,5 +1,6 @@
-import TextInput from './TextInput';
+import { TextInput, PasswordInput } from './TextInput';
 
 export {
   TextInput,
+  PasswordInput,
 };

--- a/web/components/input/text/index.sass
+++ b/web/components/input/text/index.sass
@@ -1,1 +1,2 @@
 @import ./TextInput/TextInput
+@import ./TextInput/PasswordInput/PasswordInput


### PR DESCRIPTION
## :construction_worker: Changes

![password_input_fixed](https://user-images.githubusercontent.com/21287547/42983814-ab8b9868-8b9d-11e8-8983-9f9653ed9d56.gif)

Instead of making `TextInput` component handle both regular text inputs and password inputs, I decided to make password input a separate component. It just makes more sense because password input requires the "forgot?" label and you have to specify the type as password - it's different enough from textinput that i believe it merits to be a separate component

## :thought_balloon: Notes

design: https://www.figma.com/file/KweWMEzkhgCpbpu5W9MZGE4L/nwHacks-2019-Website

## :flashlight: Testing Instructions

Go to /ui_demo, should match design https://www.figma.com/file/KweWMEzkhgCpbpu5W9MZGE4L/nwHacks-2019-Website
