### PR TITLE
init hacker application route

### DIFF
--- a/web/actions/action_types.js
+++ b/web/actions/action_types.js
@@ -1,0 +1,5 @@
+const ACTION_TYPES = Object.freeze({
+  ADD_HACKER_APPLICATION: 'ADD_HACKER_APPLICATION',
+});
+
+export default ACTION_TYPES;

--- a/web/actions/application/hacker.js
+++ b/web/actions/application/hacker.js
@@ -1,0 +1,8 @@
+import ACTION_TYPES from '../action_types';
+
+export const addHackerApplication = (hackerApplication) => {
+  return {
+    type: ACTION_TYPES.ADD_HACKER_APPLICATION,
+    hackerApplication,
+  };
+};

--- a/web/actions/application/hacker.test.js
+++ b/web/actions/application/hacker.test.js
@@ -1,0 +1,22 @@
+import { addHackerApplication } from '.';
+import ACTION_TYPES from '../action_types';
+
+describe('add hacker application', () => {
+  it('creates an action to add hacker application', () => {
+    const hackerApplication = {
+      isLoaded: true,
+      data: {
+        name: 'John Doe',
+        school: 'UBC',
+      },
+    };
+
+    const expectedAction = {
+      type: ACTION_TYPES.ADD_HACKER_APPLICATION,
+      hackerApplication,
+    };
+
+    expect(addHackerApplication(hackerApplication))
+      .toEqual(expectedAction);
+  });
+});

--- a/web/actions/application/index.js
+++ b/web/actions/application/index.js
@@ -1,0 +1,5 @@
+import { addHackerApplication } from './hacker';
+
+export {
+  addHackerApplication,
+};

--- a/web/actions/index.js
+++ b/web/actions/index.js
@@ -1,0 +1,7 @@
+import { addHackerApplication } from './application';
+import ACTION_TYPES from './action_types';
+
+export {
+  addHackerApplication,
+  ACTION_TYPES,
+};

--- a/web/components/app/App.js
+++ b/web/components/app/App.js
@@ -6,18 +6,15 @@ import { PersistGate } from 'redux-persist/integration/react';
 import Main from '../Main';
 import { Login, Logout } from '../auth';
 import AdminPanel from '../admin';
+import { HackerApplication } from '../application';
 import NotFound from '../errors/NotFound';
 import Navbar from '../../containers/navbar';
 import DashBoard from '../dashboard';
 import UIDemo from '../demo';
 
-import configureStore from '../../services/store';
+import { store, persistor } from '../../services/store/configureStore';
 
-const initialState = {};
-
-const { store, persistor } = configureStore(initialState);
-
-const App = () => (
+export const App = () => (
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
       <BrowserRouter>
@@ -27,16 +24,15 @@ const App = () => (
             <Route exact path="/" component={Main} />
             <Route path="/login" component={Login} />
             <Route path="/logout" component={Logout} />
+            <Route path="/application/hacker" component={HackerApplication} />
             <Route path="/dashboard" component={DashBoard} />
             <Route path="/admin" component={AdminPanel} />
             <Route path="/ui_demo" component={UIDemo} />
             <Route path="/page_not_found" component={NotFound} />
-            <Route path="*" component={() => <Redirect to="/page_not_found" />} />
+            <Route component={() => <Redirect to="/page_not_found" />} />
           </Switch>
         </div>
       </BrowserRouter>
     </PersistGate>
   </Provider>
 );
-
-export default App;

--- a/web/components/application/hacker/Hacker.js
+++ b/web/components/application/hacker/Hacker.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-const DashBoard = (props) => {
+const HackerApplication = (props) => {
   const { hackerApplication } = props;
   if (!hackerApplication.isLoaded) return (<div />);
-  if (hackerApplication.data) return (<div>you have one hacker application</div>);
-  return (<div>you didn&#39;t apply as hacker</div>);
+  if (hackerApplication.data) return (<Redirect to="/dashboard" />);
+  return (<div>o hello there pls apply</div>);
 };
 
 const mapStateToProps = (state) => {
@@ -16,8 +17,8 @@ const mapStateToProps = (state) => {
   };
 };
 
-DashBoard.propTypes = {
+HackerApplication.propTypes = {
   hackerApplication: PropTypes.object.isRequired,
 };
 
-export default connect(mapStateToProps)(DashBoard);
+export default connect(mapStateToProps)(HackerApplication);

--- a/web/components/application/index.js
+++ b/web/components/application/index.js
@@ -1,0 +1,5 @@
+import HackerApplication from './hacker/Hacker';
+
+export {
+  HackerApplication,
+};

--- a/web/components/auth/Login/AfterLogin.js
+++ b/web/components/auth/Login/AfterLogin.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Redirect } from 'react-router-dom';
+
+const AfterLogin = (props) => {
+  const { isLoaded } = props;
+
+  if (isLoaded) {
+    return (<Redirect to="/dashboard" />);
+  }
+
+  return (<div />);
+};
+
+AfterLogin.propTypes = {
+  isLoaded: PropTypes.bool.isRequired,
+};
+
+export default AfterLogin;

--- a/web/components/auth/Login/AfterLogin.test.js
+++ b/web/components/auth/Login/AfterLogin.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { Redirect } from 'react-router-dom';
+
+import AfterLogin from './AfterLogin';
+
+beforeAll(() => {
+  configure({ adapter: new Adapter() });
+});
+
+describe('AfterLoginContainer', () => {
+  let props;
+  let wrapper;
+  const getWrapper = () => shallow(<AfterLogin {...props} />);
+
+  describe('when hacker application is loaded', () => {
+    beforeEach(() => {
+      props = { isLoaded: true };
+      wrapper = getWrapper();
+    });
+
+    it('redirects to dashboard', () => {
+      const redirect = wrapper.find(Redirect);
+      expect(redirect).toHaveProperty('length', 1);
+      expect(wrapper.find(Redirect).props()).toHaveProperty('to', '/dashboard');
+    });
+  });
+
+  describe('when hacker application is not loaded', () => {
+    beforeEach(() => {
+      props = { isLoaded: false };
+      wrapper = getWrapper();
+    });
+
+    it('returns an empty div while loading', () => {
+      expect(wrapper.html()).toEqual('<div></div>');
+    });
+  });
+});

--- a/web/components/auth/Login/Login.js
+++ b/web/components/auth/Login/Login.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { firebaseConnect } from 'react-redux-firebase';
-import { Redirect, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
 import { TextInput, PasswordInput } from '../../input/text';
 import { PrimaryButton } from '../../input/buttons';
+import { AfterLogin } from '../../../containers/auth';
 
 class Login extends React.Component {
   constructor(props) {
@@ -98,7 +99,7 @@ class Login extends React.Component {
     if (loading) return (<span>Loading...</span>);
     if (!loggedIn) return this.loginView();
 
-    return (<Redirect to="/dashboard" />);
+    return (<AfterLogin />);
   }
 }
 
@@ -109,7 +110,11 @@ Login.propTypes = {
   auth: PropTypes.object,
 };
 
+const mapStateToProps = ({ firebase: { auth } }) => {
+  return { auth };
+};
+
 export default compose(
   firebaseConnect(),
-  connect(({ firebase: { auth } }) => { return { auth }; })
+  connect(mapStateToProps),
 )(Login);

--- a/web/components/auth/Logout/Logout.js
+++ b/web/components/auth/Logout/Logout.js
@@ -1,12 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
-import { withFirebase } from 'react-redux-firebase';
+import { withFirebase, firebaseConnect } from 'react-redux-firebase';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+
+import purgeStore from '../../../services/store/purge';
 
 class Logout extends React.Component {
   componentDidMount() {
     const { firebase } = this.props;
     firebase.logout();
+    this.purge();
+  }
+
+  purge = () => {
+    const { resetState } = this.props;
+    resetState();
+    purgeStore();
   }
 
   render() {
@@ -18,6 +29,23 @@ Logout.propTypes = {
   firebase: PropTypes.shape({
     logout: PropTypes.func.isRequired,
   }),
+  resetState: PropTypes.func.isRequired,
 };
 
-export default withFirebase(Logout);
+const mapStateToProps = ({ firebase }) => {
+  return { firebase };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    // https://www.npmjs.com/package/redux-reset
+    resetState: () => {
+      dispatch({ type: 'RESET' });
+    },
+  };
+};
+
+export default compose(
+  firebaseConnect(),
+  connect(mapStateToProps, mapDispatchToProps),
+)(withFirebase(Logout));

--- a/web/containers/auth/AfterLogin.js
+++ b/web/containers/auth/AfterLogin.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { firebaseConnect, firestoreConnect } from 'react-redux-firebase';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+
+import { addHackerApplication } from '../../actions';
+
+import AfterLogin from '../../components/auth/Login/AfterLogin';
+
+export class AfterLoginContainer extends React.Component {
+  componentWillUnmount() {
+    const { hackerApplication } = this.props;
+    const { isLoaded } = hackerApplication;
+    const { storeHackerApplication } = this.props;
+
+    if (isLoaded) {
+      storeHackerApplication(hackerApplication);
+    }
+  }
+
+  render() {
+    const { hackerApplication: { isLoaded } } = this.props;
+
+    return (<AfterLogin isLoaded={isLoaded} />);
+  }
+}
+
+const mapStateToProps = (state) => {
+  const { firebase: { auth: { uid } } } = state;
+  const {
+    firestore: {
+      data: {
+        hackerApplication,
+      },
+      status: {
+        requesting,
+      },
+    },
+  } = state;
+
+  const data = hackerApplication;
+
+  return {
+    hackerApplication: {
+      isLoaded: !requesting[`applications_hacker/${uid}`],
+      data,
+    },
+  };
+};
+
+AfterLoginContainer.propTypes = {
+  hackerApplication: PropTypes.object.isRequired,
+  storeHackerApplication: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    storeHackerApplication: (application) => {
+      dispatch(addHackerApplication(application));
+    },
+  };
+};
+
+export default compose(
+  firebaseConnect(),
+  firestoreConnect((props) => {
+    const { firebase } = props;
+    const auth = firebase.auth();
+    const { currentUser: { uid } } = auth;
+    return [
+      {
+        collection: 'applications_hacker',
+        doc: uid,
+        storeAs: 'hackerApplication',
+      },
+    ];
+  }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(AfterLoginContainer);

--- a/web/containers/auth/AfterLogin.test.js
+++ b/web/containers/auth/AfterLogin.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+import AfterLogin from '../../components/auth/Login/AfterLogin';
+import { AfterLoginContainer } from './AfterLogin';
+
+beforeAll(() => {
+  configure({ adapter: new Adapter() });
+});
+
+describe('AfterLoginContainer', () => {
+  let props;
+  let wrapper;
+  const getWrapper = () => shallow(<AfterLoginContainer {...props} />);
+
+  describe('when hacker application is loaded', () => {
+    describe('when data is not undefined', () => {
+      const action = jest.fn();
+
+      beforeEach(() => {
+        const hackerApplication = { isLoaded: true, data: { a: 'b' } };
+
+        props = {
+          hackerApplication,
+          storeHackerApplication: action,
+        };
+
+        wrapper = getWrapper();
+      });
+
+      it('isLoaded is true in AfterLogin component', () => {
+        expect(wrapper.find(AfterLogin).props()).toHaveProperty('isLoaded', true);
+      });
+
+      describe('when unmounted', () => {
+        beforeEach(() => {
+          wrapper.unmount();
+        });
+
+        it('storeHackerApplication action is called', () => {
+          expect(action.mock.calls).toHaveLength(1);
+          expect(action.mock.calls[0][0]).toEqual({ isLoaded: true, data: { a: 'b' } });
+        });
+      });
+    });
+
+    describe('when data is undefined', () => {
+      const action = jest.fn();
+
+      beforeEach(() => {
+        const hackerApplication = { isLoaded: true, data: undefined };
+
+        props = {
+          hackerApplication,
+          storeHackerApplication: action,
+        };
+
+        wrapper = getWrapper();
+      });
+
+      it('isLoaded is true in AfterLogin component', () => {
+        expect(wrapper.find(AfterLogin).props()).toHaveProperty('isLoaded', true);
+      });
+
+      describe('when unmounted', () => {
+        beforeEach(() => {
+          wrapper.unmount();
+        });
+
+        it('storeHackerApplication action is called', () => {
+          expect(action.mock.calls).toHaveLength(1);
+          expect(action.mock.calls[0][0]).toEqual({ isLoaded: true, data: undefined });
+        });
+      });
+    });
+  });
+
+  describe('when hacker application is not loaded', () => {
+    const action = jest.fn();
+
+    beforeEach(() => {
+      const hackerApplication = { isLoaded: false, data: undefined };
+
+      props = {
+        hackerApplication,
+        storeHackerApplication: action,
+      };
+
+      wrapper = getWrapper();
+    });
+
+    it('isLoaded is true in AfterLogin component', () => {
+      expect(wrapper.find(AfterLogin).props()).toHaveProperty('isLoaded', false);
+    });
+
+    describe('when unmounted', () => {
+      beforeEach(() => {
+        wrapper.unmount();
+      });
+
+      it('storeHackerApplication action is not called', () => {
+        expect(action.mock.calls).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/web/containers/auth/index.js
+++ b/web/containers/auth/index.js
@@ -1,0 +1,5 @@
+import AfterLogin from './AfterLogin';
+
+export {
+  AfterLogin,
+};

--- a/web/index.js
+++ b/web/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import App from './components/app/App';
+import { App } from './components/app/App';
 import './styles/index.sass';
 
 ReactDOM.render(<App />, document.getElementById('app'));

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
       "\\.(css|less|scss|sass)$": "identity-obj-proxy"
     },
     "collectCoverage": true,
-    "collectCoverageFrom" : [
+    "collectCoverageFrom": [
       "**/*.js",
       "!**/node_modules/**",
       "!**/*.test.js",
@@ -27,7 +27,10 @@
       "!**/coverage/**",
       "!**/tests/**"
     ],
-    "coverageReporters": ["text", "json"]
+    "coverageReporters": [
+      "text",
+      "json"
+    ]
   },
   "dependencies": {
     "@firebase/app": "0.3.3",

--- a/web/reducers/application/hacker.js
+++ b/web/reducers/application/hacker.js
@@ -1,0 +1,17 @@
+import { ACTION_TYPES } from '../../actions';
+
+const initialState = {
+  isLoaded: true,
+  data: undefined,
+};
+
+const hackerApplication = (state = initialState, action) => {
+  switch (action.type) {
+    case ACTION_TYPES.ADD_HACKER_APPLICATION:
+      return action.hackerApplication;
+    default:
+      return state;
+  }
+};
+
+export default hackerApplication;

--- a/web/reducers/application/hacker.test.js
+++ b/web/reducers/application/hacker.test.js
@@ -1,0 +1,64 @@
+import rootReducers from '..';
+import { hackerApplication } from '.';
+import ACTION_TYPES from '../../actions/action_types';
+
+describe('hacker application reducer', () => {
+  describe('when state is undefined', () => {
+    it('returns the initial state', () => {
+      expect(hackerApplication(undefined, {})).toEqual({
+        isLoaded: true,
+        data: undefined,
+      });
+    });
+  });
+
+  describe('when type is ADD_HACKER_APPLICATION', () => {
+    it('handles the action', () => {
+      expect(
+        hackerApplication({}, {
+          type: ACTION_TYPES.ADD_HACKER_APPLICATION,
+          hackerApplication: {
+            name: 'John Doe',
+            school: 'UBC',
+          },
+        })
+      ).toEqual({
+        name: 'John Doe',
+        school: 'UBC',
+      });
+    });
+  });
+
+  describe('when type is not ADD_HACKER_APPLICATION and state is not undefined', () => {
+    it('returns the state', () => {
+      expect(
+        hackerApplication(
+          { beforeState: 'before state' },
+          { type: 'some action type', data: '1234' }
+        )
+      ).toEqual({ beforeState: 'before state' });
+    });
+  });
+});
+
+describe('when action type is RESET', () => {
+  it('resets hackerApplication to default state', () => {
+    const state = {
+      hackerApplication: {
+        isLoaded: true,
+        data: {
+          name: 'John Doe',
+          school: 'UBC',
+        },
+      },
+    };
+
+    const action = { type: 'RESET' };
+    expect(rootReducers(state, action)).toEqual({
+      hackerApplication: {
+        isLoaded: true,
+        data: undefined,
+      },
+    });
+  });
+});

--- a/web/reducers/application/index.js
+++ b/web/reducers/application/index.js
@@ -1,0 +1,5 @@
+import hackerApplication from './hacker';
+
+export {
+  hackerApplication,
+};

--- a/web/reducers/index.js
+++ b/web/reducers/index.js
@@ -1,0 +1,16 @@
+import { combineReducers } from 'redux';
+import { hackerApplication } from './application';
+
+const reducers = combineReducers({
+  hackerApplication,
+});
+
+const rootReducers = (state, action) => {
+  if (action.type === 'RESET') {
+    state = undefined;
+  }
+
+  return reducers(state, action);
+};
+
+export default rootReducers;

--- a/web/services/store/configureStore.js
+++ b/web/services/store/configureStore.js
@@ -1,0 +1,5 @@
+import configureStore from '.';
+
+const initialState = {};
+
+export const { store, persistor } = configureStore(initialState);

--- a/web/services/store/index.js
+++ b/web/services/store/index.js
@@ -11,11 +11,9 @@ import localStorage from 'redux-persist/lib/storage';
 import hardSet from 'redux-persist/lib/stateReconciler/hardSet';
 
 import { firebaseConfig, rrfConfig } from '../../main.config';
+import Reducers from '../../reducers';
 
-const persistConfig = {
-  key: 'root',
-  storage: localStorage,
-};
+import { persistConfig } from './persist.config';
 
 export default (initialState = {}) => {
   // Initialize firebase instance
@@ -28,7 +26,7 @@ export default (initialState = {}) => {
   // Add reactReduxFirebase store enhancer when making store creator
   const createStoreWithFirebase = compose(
     reactReduxFirebase(firebase, rrfConfig),
-    reduxFirestore(firebase)
+    reduxFirestore(firebase),
   )(createStore);
 
   // Add firebase to reducers (uses persistReducer and hardSet)
@@ -38,6 +36,7 @@ export default (initialState = {}) => {
       firebaseReducer
     ),
     firestore: firestoreReducer,
+    root: Reducers,
   });
 
   const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/web/services/store/persist.config.js
+++ b/web/services/store/persist.config.js
@@ -1,0 +1,6 @@
+import localStorage from 'redux-persist/lib/storage';
+
+export const persistConfig = {
+  key: 'root',
+  storage: localStorage,
+};

--- a/web/services/store/purge.js
+++ b/web/services/store/purge.js
@@ -1,0 +1,3 @@
+import { persistor } from './configureStore';
+
+export default () => { persistor.purge(); };

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, './public'),
     filename: 'bundle.js',
+    publicPath: '/',
   },
   // sourcemaps are currently broken
   // devtool: 'inline-source-map',


### PR DESCRIPTION
## :construction_worker: Changes

Introduces `application/hacker` route! It also calls Firestore to determine whether the user has already applied or not (if logged in).

## :thought_balloon: Notes

This PR is also the beginning of storing essential user information into redux on login, and destroying the store on logout. In this PR, we store the hacker application into the store as the user logs in, so that we have that hacker application ready when the login redirects to dashboard. We could also do the same for determining if the user is admin, and a lot of other handy stuff that we know we'll need for sure.

## :flashlight: Testing Instruction

### User has already submitted a hacker application
* create a user on firebase authentication
* create a doc in `applications_hacker` with the user's `uid` as the `id`
* Login as that user
- [ ] dashboard says "you have one hacker application"
* go to `application/hacker`
- [ ] you are redirected back to `/dashboard`

### User has not already submitted a hacker application
* create a user on firebase authentication
* ensure there's no doc in`applications_hacker` whose `id` matches the user's `uid`
* Login as that user
- [ ] dashboard says "you didn't apply as a hacker"
* go to `application/hacker`
- [ ] you are not redirected to `/dashboard` and tells you to apply