### PR TITLE
Dev deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+inertia.toml
+
 # IDEs, text editors
 .vscode
 

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,0 +1,12 @@
+FROM node:carbon
+
+COPY .env .env
+COPY web/package.json web/package.json
+COPY web/yarn.lock web/yarn.lock
+
+WORKDIR web
+RUN yarn install --production --silent
+COPY web .
+
+EXPOSE 8080
+ENTRYPOINT [ "yarn", "start", "--host", "0.0.0.0" ]

--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
     "babel-minify-webpack-plugin": "0.3.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-polyfill": "6.26.0",
+    "babel-preset-env": "1.7.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
@@ -73,7 +74,6 @@
   },
   "devDependencies": {
     "babel-jest": "23.2.0",
-    "babel-preset-env": "1.7.0",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "eslint": "5.0.1",

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
   // devtool: 'inline-source-map',
   devServer: {
     historyApiFallback: true,
+    disableHostCheck: true,
   },
   // Handles missing fs module
   node: {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1456,7 +1456,7 @@ babel-polyfill@6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@1.7.0:
+babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:


### PR DESCRIPTION
## :construction_worker: Changes

Adds Dockerfile config and some tweaks to enable hosting via `webpack-dev-server` so that we can use dev credentials... this is currently online at an EC2 instance I shall put up somewhere on internal docs. Once we merge this, I can configure it to deploy `master` automatically, or switch branches as needed, and when my free EC2 instance expires I can get a free trial elsewhere and move this deployment without much effort.

The deployed instance uses the dev credentials.

## :thought_balloon: Notes

This was set up using https://github.com/ubclaunchpad/inertia, which I built 😛 hope that's okay!

## :flashlight: Testing Instructions

See slack channel for address of deployment!
