### PR TITLE
Web/flexbox utils, login style rework

### DIFF
--- a/web/components/auth/Login/Login.js
+++ b/web/components/auth/Login/Login.js
@@ -52,14 +52,14 @@ class Login extends React.Component {
   loginView() {
     const { email, password, error } = this.state;
     return (
-      <div id="login">
+      <div id="login" className="fill-height flex jc-center ai-center dir-col">
         <div>
           <form
             onSubmit={this.login}
             className="input-group">
-            <span>Sign in</span>
-            <div className="card">
-              <div className="card-left">
+            <h2 className="pad-sides">Sign in</h2>
+            <div className="card split flex">
+              <div className="pad-ends pad-sides margin-text-inputs">
                 <TextInput
                   placeholder="Enter your email"
                   value={email}
@@ -79,8 +79,9 @@ class Login extends React.Component {
                 />
                 <PrimaryButton
                   text="Submit"
+                  className="fill-width"
                   />
-                <p>
+                <p className="flex jc-center">
                   Don&apos;t have an account yet?&nbsp;
                   <Link to="/">Apply here</Link>
                 </p>

--- a/web/components/auth/Login/Login.sass
+++ b/web/components/auth/Login/Login.sass
@@ -1,88 +1,13 @@
 div#login
-  display: flex
-  justify-content: center
-  height: 100%
-  align-items: center
-
   > div
     max-width: 748px
     width: 60%
-    display: flex
-    flex-direction: column
-    align-items: center
 
     form
       height: 60%
       min-height: 400px
 
-      width: 100%
-
-      display: flex
-      flex-direction: column
-      justify-content: center
-
-      > span
-        padding-left: 44px
-        padding-right: 44px
-
-        width: 100%
-        display: flex
-        justify-content: flex-start
-
-        font-family: Merriweather
-        font-style: normal
-        font-weight: bold
-        line-height: normal
-        font-size: 32px
-
-        color: $primary
-
-        margin-bottom: 28px
-
-      div.card
-        display: flex
-        background-color: $white
-        overflow: hidden
-
-        /* Drop shadow */
-        box-shadow: 0px 4px 6px $shadow
-        border-radius: 4px
-
-        > *
-          width: 50%
-
-        > div.card-left
-          padding-left: 44px
-          padding-right: 44px
-          padding-top: 48px
-          padding-bottom: 48px
-
-          > div.text-input
-            &:first-of-type
-              margin-bottom: 40px
-            &:last-of-type
-              margin-bottom: 56px
-
-          > button
-            width: 100%
-
-          > p
-            display: flex
-            justify-content: center
-
-            margin-top: 10px
-            width: 100%
-            font-family: Apercu Pro
-            font-size: 14px
-            color: $primary
-
-            > a
-              &:visited
-                color: $primary
-
-              &:hover
-                color: $secondary-highlight
-
-        > div.card-right
-          /* Placeholder for future illustration
+      > .card
+        > .card-right
+          /* Placeholder for future illustration */
           background: linear-gradient(180deg, #2C31AE 0%, #21258A 100%)

--- a/web/components/input/buttons/PrimaryButton/index.js
+++ b/web/components/input/buttons/PrimaryButton/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const PrimaryButton = ({ text, onClick, disabled }) => (
+const PrimaryButton = ({ text, onClick, disabled, className }) => (
   <button
     onClick={onClick}
     type="submit"
     disabled={disabled}
-    className="primary">
+    className={`primary ${className}`}>
     { text }
   </button>
 );
@@ -15,6 +15,7 @@ PrimaryButton.propTypes = {
   text: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default PrimaryButton;

--- a/web/styles/breakpoints.sass
+++ b/web/styles/breakpoints.sass
@@ -1,0 +1,5 @@
+$desktop: 1300px;
+$laptop: 1080px;
+$tablet: 900px;
+$phablet: 760px;
+$mobile: 480px;

--- a/web/styles/decoration.sass
+++ b/web/styles/decoration.sass
@@ -1,8 +1,8 @@
 .shadow
   box-shadow: 0px 4px 6px $shadow
-  border-radius: 4px
 
 .card
   @extend .shadow
+  border-radius: 4px
   background-color: $white
   overflow: hidden

--- a/web/styles/decoration.sass
+++ b/web/styles/decoration.sass
@@ -1,0 +1,8 @@
+.shadow
+  box-shadow: 0px 4px 6px $shadow
+  border-radius: 4px
+
+.card
+  @extend .shadow
+  background-color: $white
+  overflow: hidden

--- a/web/styles/index.sass
+++ b/web/styles/index.sass
@@ -2,6 +2,7 @@
 @import ./colors
 @import ./typography
 @import ./animations
+@import ./utils
 
 /* components */
 @import ../components/index

--- a/web/styles/index.sass
+++ b/web/styles/index.sass
@@ -4,6 +4,7 @@
 @import ./animations
 @import ./utils
 @import ./breakpoints
+@import ./decoration
 
 /* components */
 @import ../components/index
@@ -11,8 +12,9 @@
 /* containers */
 @import ../containers/index
 
+// Remove from here once definitions are set up
 html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+h1, h3, h4, h5, h6, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, strong, sub, sup, tt, var,
@@ -28,7 +30,6 @@ time, mark, audio, video
   margin: 0
   padding: 0
   border: 0
-  font: inherit
   vertical-align: baseline
 
 html
@@ -38,7 +39,6 @@ html
 body
   height: 100%
   width: 100%
-  font-family: 'Merriweather', serif
 
 #app
   height: 100%

--- a/web/styles/index.sass
+++ b/web/styles/index.sass
@@ -3,6 +3,7 @@
 @import ./typography
 @import ./animations
 @import ./utils
+@import ./breakpoints
 
 /* components */
 @import ../components/index

--- a/web/styles/typography.sass
+++ b/web/styles/typography.sass
@@ -15,3 +15,27 @@
   font-weight: normal
   font-style: normal
   src: url(./fonts/apercu_regular_pro.otf) format('opentype')
+
+a
+  &:visited
+    color: $primary
+
+  &:hover
+    color: $secondary-highlight
+
+p
+  font-size: 14px
+  font-family: Apercu Pro
+  color: $primary
+  margin-top: 10px
+
+h2
+  font-family: Merriweather
+  font-style: normal
+  font-weight: bold
+  line-height: normal
+  font-size: 32px
+  color: $primary
+  padding-left: 44px
+  padding-right: 44px
+  margin-bottom: 28px

--- a/web/styles/utils.sass
+++ b/web/styles/utils.sass
@@ -1,8 +1,43 @@
-/* flexbox utility classes */
+.fill
+  &-width
+    width: 100%
+
+  &-height
+    height: 100%
+
+.split
+  > *
+    width: 50%
+
+// padding declarations
+.pad
+  &-sides
+    padding-left: 44px
+    padding-right: 44px
+
+  &-ends
+    padding-top: 48px
+    padding-bottom: 48px
+
+// margin declarations
+.margin
+  &-text-inputs
+    > .text-input
+      &:first-of-type
+        margin-bottom: 40px
+      &:last-of-type
+        margin-bottom: 56px
+
+// flexbox utility classes
 .flex
   display: flex
 
-  /* content justification */
+  // flex-directions
+  &.dir
+    &-col
+      flex-direction: column
+
+  // justify-content
   &.jc
     &-center
       justify-content: center
@@ -17,10 +52,11 @@
           align-self: flex-end
           margin-left: auto
 
+  // flex-wrap
   &.wrap
     flex-wrap: wrap
 
-  /* item alignment */
+  // align-items
   &.ai
     &-center
       align-items: center

--- a/web/styles/utils.sass
+++ b/web/styles/utils.sass
@@ -1,0 +1,26 @@
+/* flexbox utility classes */
+.flex
+  display: flex
+
+  /* content justification */
+  &.jc
+    &-center
+      justify-content: center
+
+    &-around
+      justify-content: space-around
+
+    &-between
+      justify-content: space-between
+      &-right-if-one
+        :only-child
+          align-self: flex-end
+          margin-left: auto
+
+  &.wrap
+    flex-wrap: wrap
+
+  /* item alignment */
+  &.ai
+    &-center
+      align-items: center


### PR DESCRIPTION
Closes #36

## :construction_worker: Changes

Alright, so this ended up being a bit bigger than expected. Recommend reading this for the rationale behind my changes and what we should do with these going forward.

- Added `.flex` in `utils.sass` - these are the flexbox utilities i mentioned
- Added `breakpoints.sass`, though these aren't in use yet. just to get the ball rolling on responsive design

Then I started looking into getting these implemented as an example, and noticed that the Login page's style is *super specific*... guess it didnt seem too bad in the review. So I:

- moved text styles into global `a`, `h2`, `p` - hopefully this helps with uniformity
- moved padding, margin, width/height styles into global classes in `utils.sass`
- added `decorations.sass` for decorative styles, like shadows - other classes will need to be updated to use these
- completely gutted Login style to reduce its complexity and utilize the existing classes as much as possible

The new stylesheet **only declares constraints** and super specific styles:

```sass
div#login
  > div
    max-width: 748px
    width: 60%

    form
      height: 60%
      min-height: 400px

      > .card
        > .card-right
          background: linear-gradient(180deg, #2C31AE 0%, #21258A 100%)
```

The resultant, clean, declarative JSX:

```js
      <div id="login" className="fill-height flex jc-center ai-center dir-col">
        <div>
          <form
            onSubmit={this.login}
            className="input-group">
            <h2 className="pad-sides">Sign in</h2>
            <div className="card split flex">
              <div className="pad-ends pad-sides margin-text-inputs">
                <TextInput
                  placeholder="Enter your email"
                  value={email}
                  onChange={this.onEmailChange}
                  error={error}
                  label="Email"
                  id="email"
                />
                <PasswordInput
                  placeholder="Enter your password"
                  value={password}
                  onChange={this.onPasswordChange}
                  error={error}
                  label="Password"
                  id="password"
                  showErrorMessage
                />
                <PrimaryButton
                  text="Submit"
                  className="fill-width"
                  />
                <p className="flex jc-center">
                  Don&apos;t have an account yet?&nbsp;
                  <Link to="/">Apply here</Link>
                </p>
              </div>
              <div className="card-right" />
            </div>
          </form>
        </div>
      </div>
```

## :thought_balloon: Notes

The goal with this is to reduce style duplication as much as possible, and achieve a more uniform look. If all our `p` have the same margins, it would be far easier to set up new elements that look like they fit in, for example.

This goes especially in padding - nothing looks weirder than padding that varies like crazy, so having a set of padding classes to choose from is a good idea. Plus, this means it'll be easier to implement responsiveness - for example, all classes with a certain padding class should lose/reduce their padding at the same breakpoints.

So why do all this instead of fancy, deeply nested styles that depend on a very specific hierarchy of elements? Because as soon as you move anything, say, one level of nesting deeper:

<img width="192" alt="image" src="https://user-images.githubusercontent.com/23356519/43882921-4c60d348-9b66-11e8-9cdc-3e88ffe81177.png">

It also obscures a lot of the style logic, and makes it very hard to find what's doing what. More declarative classes = clearer style structures = happier time maintaining and adding to this stuff later on.

Also, just less styles in general. If additional variations are needed, just add subclasses.

For another example, see #41 

## :flashlight: Testing Instructions

```make web```, everything should look the same